### PR TITLE
feat: accept expressions for labels in instrument macro

### DIFF
--- a/crates/channels-console-futures-test/examples/basic_futures.rs
+++ b/crates/channels-console-futures-test/examples/basic_futures.rs
@@ -2,19 +2,28 @@ use futures_util::stream::StreamExt;
 use smol::Timer;
 use std::time::Duration;
 
+struct Actor {
+    name: String,
+}
+
 #[allow(unused_mut)]
 fn main() {
     smol::block_on(async {
+        let actor1 = Actor {
+            name: "Actor 1".to_string(),
+        };
+
         #[cfg(feature = "channels-console")]
         let _channels_guard = channels_console::ChannelsGuard::new();
 
         let (txa, mut _rxa) = futures_channel::mpsc::unbounded::<i32>();
         #[cfg(feature = "channels-console")]
-        let (txa, mut _rxa) = channels_console::instrument!((txa, _rxa));
+        let (txa, mut _rxa) = channels_console::instrument!((txa, _rxa), label = actor1.name);
 
         let (mut txb, mut rxb) = futures_channel::mpsc::channel::<i32>(10);
         #[cfg(feature = "channels-console")]
-        let (mut txb, mut rxb) = channels_console::instrument!((txb, rxb), capacity = 10);
+        let (mut txb, mut rxb) =
+            channels_console::instrument!((txb, rxb), capacity = 10, label = "bounded-channel");
 
         let (txc, rxc) = futures_channel::oneshot::channel::<String>();
         #[cfg(feature = "channels-console")]

--- a/crates/channels-console-futures-test/examples/iter_futures.rs
+++ b/crates/channels-console-futures-test/examples/iter_futures.rs
@@ -1,9 +1,17 @@
 use smol::Timer;
 use std::time::Duration;
 
+struct Actor {
+    name: String,
+}
+
 #[allow(unused_mut)]
 fn main() {
     smol::block_on(async {
+        let actor1 = Actor {
+            name: "Actor 1".to_string(),
+        };
+
         #[cfg(feature = "channels-console")]
         let _channels_guard = channels_console::ChannelsGuard::new();
 
@@ -14,7 +22,7 @@ fn main() {
             let (tx, mut rx) = futures_channel::mpsc::unbounded::<i32>();
 
             #[cfg(feature = "channels-console")]
-            let (tx, mut rx) = channels_console::instrument!((tx, rx));
+            let (tx, mut rx) = channels_console::instrument!((tx, rx), label = actor1.name.clone());
 
             println!("  - Created unbounded channel {}", i);
 

--- a/crates/channels-console-std-test/examples/basic_std.rs
+++ b/crates/channels-console-std-test/examples/basic_std.rs
@@ -1,17 +1,25 @@
 use std::thread;
 use std::time::Duration;
 
+struct Actor {
+    name: String,
+}
+
 fn main() {
+    let actor1 = Actor {
+        name: "Actor 1".to_string(),
+    };
+
     #[cfg(feature = "channels-console")]
     let _channels_guard = channels_console::ChannelsGuard::new();
 
     let (txa, _rxa) = std::sync::mpsc::channel::<i32>();
     #[cfg(feature = "channels-console")]
-    let (txa, _rxa) = channels_console::instrument!((txa, _rxa));
+    let (txa, _rxa) = channels_console::instrument!((txa, _rxa), label = "unbounded-channel");
 
     let (txb, rxb) = std::sync::mpsc::sync_channel::<i32>(10);
     #[cfg(feature = "channels-console")]
-    let (txb, rxb) = channels_console::instrument!((txb, rxb), capacity = 10, label = "zzz");
+    let (txb, rxb) = channels_console::instrument!((txb, rxb), capacity = 10, label = actor1.name);
 
     let sender_handle = thread::spawn(move || {
         for i in 1..=3 {

--- a/crates/channels-console-std-test/examples/iter_std.rs
+++ b/crates/channels-console-std-test/examples/iter_std.rs
@@ -2,7 +2,15 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
+struct Actor {
+    name: String,
+}
+
 fn main() {
+    let actor1 = Actor {
+        name: "Actor 1".to_string(),
+    };
+
     #[cfg(feature = "channels-console")]
     let _channels_guard = channels_console::ChannelsGuard::new();
 
@@ -14,7 +22,7 @@ fn main() {
         let (tx, rx) = mpsc::channel::<i32>();
 
         #[cfg(feature = "channels-console")]
-        let (tx, rx) = channels_console::instrument!((tx, rx));
+        let (tx, rx) = channels_console::instrument!((tx, rx), label = actor1.name.clone());
 
         println!("  - Created unbounded channel {}", i);
 

--- a/crates/channels-console-tokio-test/examples/basic_tokio.rs
+++ b/crates/channels-console-tokio-test/examples/basic_tokio.rs
@@ -1,17 +1,25 @@
+struct Actor {
+    name: String,
+}
+
 #[allow(unused_mut)]
 #[tokio::main]
 async fn main() {
+    let actor1 = Actor {
+        name: "Actor 1".to_string(),
+    };
+
     #[cfg(feature = "channels-console")]
     let _channels_guard = channels_console::ChannelsGuard::new();
 
     let (txa, mut _rxa) = tokio::sync::mpsc::unbounded_channel::<i32>();
 
     #[cfg(feature = "channels-console")]
-    let (txa, _rxa) = channels_console::instrument!((txa, _rxa), log = true);
+    let (txa, _rxa) = channels_console::instrument!((txa, _rxa), log = true, label = actor1.name);
 
     let (txb, mut rxb) = tokio::sync::mpsc::channel::<i32>(10);
     #[cfg(feature = "channels-console")]
-    let (txb, mut rxb) = channels_console::instrument!((txb, rxb));
+    let (txb, mut rxb) = channels_console::instrument!((txb, rxb), label = "bounded-channel");
 
     let (txc, rxc) = tokio::sync::oneshot::channel::<String>();
     #[cfg(feature = "channels-console")]

--- a/crates/channels-console-tokio-test/examples/iter_tokio.rs
+++ b/crates/channels-console-tokio-test/examples/iter_tokio.rs
@@ -1,6 +1,14 @@
+struct Actor {
+    name: String,
+}
+
 #[allow(unused_mut)]
 #[tokio::main]
 async fn main() {
+    let actor1 = Actor {
+        name: "Actor 1".to_string(),
+    };
+
     #[cfg(feature = "channels-console")]
     let _channels_guard = channels_console::ChannelsGuard::new();
 
@@ -11,7 +19,7 @@ async fn main() {
         let (tx, mut rx) = tokio::sync::mpsc::channel::<i32>(10);
 
         #[cfg(feature = "channels-console")]
-        let (tx, mut rx) = channels_console::instrument!((tx, rx), label = "bounded");
+        let (tx, mut rx) = channels_console::instrument!((tx, rx), label = actor1.name.clone());
 
         println!("  - Created bounded channel {}", i);
 

--- a/crates/channels-console/src/channels_guard.rs
+++ b/crates/channels-console/src/channels_guard.rs
@@ -140,7 +140,7 @@ impl Drop for ChannelsGuard {
                 for channel_stats in stats {
                     let label = resolve_label(
                         channel_stats.source,
-                        channel_stats.label,
+                        channel_stats.label.as_deref(),
                         channel_stats.iter,
                     );
                     table.add_row(Row::new(vec![

--- a/crates/channels-console/src/wrappers/crossbeam.rs
+++ b/crates/channels-console/src/wrappers/crossbeam.rs
@@ -8,7 +8,7 @@ use crate::{init_stats_state, ChannelType, StatsEvent, CHANNEL_ID_COUNTER};
 fn wrap_bounded_impl<T, F>(
     inner: (Sender<T>, Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
     capacity: usize,
     mut log_on_send: F,
 ) -> (Sender<T>, Receiver<T>)
@@ -112,7 +112,7 @@ where
 pub(crate) fn wrap_bounded<T: Send + 'static>(
     inner: (Sender<T>, Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
     capacity: usize,
 ) -> (Sender<T>, Receiver<T>) {
     wrap_bounded_impl(inner, source, label, capacity, |_| None)
@@ -122,7 +122,7 @@ pub(crate) fn wrap_bounded<T: Send + 'static>(
 pub(crate) fn wrap_bounded_log<T: Send + std::fmt::Debug + 'static>(
     inner: (Sender<T>, Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
     capacity: usize,
 ) -> (Sender<T>, Receiver<T>) {
     wrap_bounded_impl(inner, source, label, capacity, |msg| {
@@ -134,7 +134,7 @@ pub(crate) fn wrap_bounded_log<T: Send + std::fmt::Debug + 'static>(
 fn wrap_unbounded_impl<T, F>(
     inner: (Sender<T>, Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
     mut log_on_send: F,
 ) -> (Sender<T>, Receiver<T>)
 where
@@ -236,7 +236,7 @@ where
 pub(crate) fn wrap_unbounded<T: Send + 'static>(
     inner: (Sender<T>, Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
 ) -> (Sender<T>, Receiver<T>) {
     wrap_unbounded_impl(inner, source, label, |_| None)
 }
@@ -245,7 +245,7 @@ pub(crate) fn wrap_unbounded<T: Send + 'static>(
 pub(crate) fn wrap_unbounded_log<T: Send + std::fmt::Debug + 'static>(
     inner: (Sender<T>, Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
 ) -> (Sender<T>, Receiver<T>) {
     wrap_unbounded_impl(inner, source, label, |msg| Some(format!("{:?}", msg)))
 }
@@ -259,7 +259,7 @@ impl<T: Send + 'static> Instrument
     fn instrument(
         self,
         source: &'static str,
-        label: Option<&'static str>,
+        label: Option<String>,
         _capacity: Option<usize>,
     ) -> Self::Output {
         // Crossbeam uses the same Sender/Receiver types for both bounded and unbounded
@@ -280,7 +280,7 @@ impl<T: Send + std::fmt::Debug + 'static> InstrumentLog
     fn instrument_log(
         self,
         source: &'static str,
-        label: Option<&'static str>,
+        label: Option<String>,
         _capacity: Option<usize>,
     ) -> Self::Output {
         // Crossbeam uses the same Sender/Receiver types for both bounded and unbounded

--- a/crates/channels-console/src/wrappers/futures.rs
+++ b/crates/channels-console/src/wrappers/futures.rs
@@ -12,7 +12,7 @@ use crate::{init_stats_state, ChannelType, StatsEvent, CHANNEL_ID_COUNTER};
 fn wrap_channel_impl<T, F>(
     inner: (Sender<T>, Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
     capacity: usize,
     mut get_msg_log: F,
 ) -> (Sender<T>, Receiver<T>)
@@ -106,7 +106,7 @@ where
 pub(crate) fn wrap_channel<T: Send + 'static>(
     inner: (Sender<T>, Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
     capacity: usize,
 ) -> (Sender<T>, Receiver<T>) {
     wrap_channel_impl(inner, source, label, capacity, |_| None)
@@ -116,7 +116,7 @@ pub(crate) fn wrap_channel<T: Send + 'static>(
 pub(crate) fn wrap_channel_log<T: Send + std::fmt::Debug + 'static>(
     inner: (Sender<T>, Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
     capacity: usize,
 ) -> (Sender<T>, Receiver<T>) {
     wrap_channel_impl(inner, source, label, capacity, |msg| {
@@ -128,7 +128,7 @@ pub(crate) fn wrap_channel_log<T: Send + std::fmt::Debug + 'static>(
 fn wrap_unbounded_impl<T, F>(
     inner: (UnboundedSender<T>, UnboundedReceiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
     mut get_msg_log: F,
 ) -> (UnboundedSender<T>, UnboundedReceiver<T>)
 where
@@ -220,7 +220,7 @@ where
 pub(crate) fn wrap_unbounded<T: Send + 'static>(
     inner: (UnboundedSender<T>, UnboundedReceiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
 ) -> (UnboundedSender<T>, UnboundedReceiver<T>) {
     wrap_unbounded_impl(inner, source, label, |_| None)
 }
@@ -229,7 +229,7 @@ pub(crate) fn wrap_unbounded<T: Send + 'static>(
 pub(crate) fn wrap_unbounded_log<T: Send + std::fmt::Debug + 'static>(
     inner: (UnboundedSender<T>, UnboundedReceiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
 ) -> (UnboundedSender<T>, UnboundedReceiver<T>) {
     wrap_unbounded_impl(inner, source, label, |msg| Some(format!("{:?}", msg)))
 }
@@ -238,7 +238,7 @@ pub(crate) fn wrap_unbounded_log<T: Send + std::fmt::Debug + 'static>(
 fn wrap_oneshot_impl<T, F>(
     inner: (oneshot::Sender<T>, oneshot::Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
     mut get_msg_log: F,
 ) -> (oneshot::Sender<T>, oneshot::Receiver<T>)
 where
@@ -353,7 +353,7 @@ where
 pub(crate) fn wrap_oneshot<T: Send + 'static>(
     inner: (oneshot::Sender<T>, oneshot::Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
 ) -> (oneshot::Sender<T>, oneshot::Receiver<T>) {
     wrap_oneshot_impl(inner, source, label, |_| None)
 }
@@ -362,7 +362,7 @@ pub(crate) fn wrap_oneshot<T: Send + 'static>(
 pub(crate) fn wrap_oneshot_log<T: Send + std::fmt::Debug + 'static>(
     inner: (oneshot::Sender<T>, oneshot::Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
 ) -> (oneshot::Sender<T>, oneshot::Receiver<T>) {
     wrap_oneshot_impl(inner, source, label, |msg| Some(format!("{:?}", msg)))
 }
@@ -382,7 +382,7 @@ impl<T: Send + 'static> Instrument
     fn instrument(
         self,
         source: &'static str,
-        label: Option<&'static str>,
+        label: Option<String>,
         capacity: Option<usize>,
     ) -> Self::Output {
         if capacity.is_none() {
@@ -405,7 +405,7 @@ impl<T: Send + 'static> Instrument
     fn instrument(
         self,
         source: &'static str,
-        label: Option<&'static str>,
+        label: Option<String>,
         _capacity: Option<usize>,
     ) -> Self::Output {
         wrap_unbounded(self, source, label)
@@ -425,7 +425,7 @@ impl<T: Send + 'static> Instrument
     fn instrument(
         self,
         source: &'static str,
-        label: Option<&'static str>,
+        label: Option<String>,
         _capacity: Option<usize>,
     ) -> Self::Output {
         wrap_oneshot(self, source, label)
@@ -447,7 +447,7 @@ impl<T: Send + std::fmt::Debug + 'static> InstrumentLog
     fn instrument_log(
         self,
         source: &'static str,
-        label: Option<&'static str>,
+        label: Option<String>,
         capacity: Option<usize>,
     ) -> Self::Output {
         if capacity.is_none() {
@@ -470,7 +470,7 @@ impl<T: Send + std::fmt::Debug + 'static> InstrumentLog
     fn instrument_log(
         self,
         source: &'static str,
-        label: Option<&'static str>,
+        label: Option<String>,
         _capacity: Option<usize>,
     ) -> Self::Output {
         wrap_unbounded_log(self, source, label)
@@ -490,7 +490,7 @@ impl<T: Send + std::fmt::Debug + 'static> InstrumentLog
     fn instrument_log(
         self,
         source: &'static str,
-        label: Option<&'static str>,
+        label: Option<String>,
         _capacity: Option<usize>,
     ) -> Self::Output {
         wrap_oneshot_log(self, source, label)

--- a/crates/channels-console/src/wrappers/std.rs
+++ b/crates/channels-console/src/wrappers/std.rs
@@ -8,7 +8,7 @@ use crate::{init_stats_state, ChannelType, StatsEvent, CHANNEL_ID_COUNTER};
 fn wrap_sync_channel_impl<T, F>(
     inner: (SyncSender<T>, Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
     capacity: usize,
     mut log_on_send: F,
 ) -> (SyncSender<T>, Receiver<T>)
@@ -113,7 +113,7 @@ where
 pub(crate) fn wrap_sync_channel<T: Send + 'static>(
     inner: (SyncSender<T>, Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
     capacity: usize,
 ) -> (SyncSender<T>, Receiver<T>) {
     wrap_sync_channel_impl(inner, source, label, capacity, |_| None)
@@ -123,7 +123,7 @@ pub(crate) fn wrap_sync_channel<T: Send + 'static>(
 pub(crate) fn wrap_sync_channel_log<T: Send + std::fmt::Debug + 'static>(
     inner: (SyncSender<T>, Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
     capacity: usize,
 ) -> (SyncSender<T>, Receiver<T>) {
     wrap_sync_channel_impl(inner, source, label, capacity, |msg| {
@@ -135,7 +135,7 @@ pub(crate) fn wrap_sync_channel_log<T: Send + std::fmt::Debug + 'static>(
 fn wrap_channel_impl<T, F>(
     inner: (Sender<T>, Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
     mut log_on_send: F,
 ) -> (Sender<T>, Receiver<T>)
 where
@@ -238,7 +238,7 @@ where
 pub(crate) fn wrap_channel<T: Send + 'static>(
     inner: (Sender<T>, Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
 ) -> (Sender<T>, Receiver<T>) {
     wrap_channel_impl(inner, source, label, |_| None)
 }
@@ -247,7 +247,7 @@ pub(crate) fn wrap_channel<T: Send + 'static>(
 pub(crate) fn wrap_channel_log<T: Send + std::fmt::Debug + 'static>(
     inner: (Sender<T>, Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
 ) -> (Sender<T>, Receiver<T>) {
     wrap_channel_impl(inner, source, label, |msg| Some(format!("{:?}", msg)))
 }
@@ -259,7 +259,7 @@ impl<T: Send + 'static> Instrument for (std::sync::mpsc::Sender<T>, std::sync::m
     fn instrument(
         self,
         source: &'static str,
-        label: Option<&'static str>,
+        label: Option<String>,
         _capacity: Option<usize>,
     ) -> Self::Output {
         wrap_channel(self, source, label)
@@ -273,7 +273,7 @@ impl<T: Send + 'static> Instrument
     fn instrument(
         self,
         source: &'static str,
-        label: Option<&'static str>,
+        label: Option<String>,
         capacity: Option<usize>,
     ) -> Self::Output {
         if capacity.is_none() {
@@ -292,7 +292,7 @@ impl<T: Send + std::fmt::Debug + 'static> InstrumentLog
     fn instrument_log(
         self,
         source: &'static str,
-        label: Option<&'static str>,
+        label: Option<String>,
         _capacity: Option<usize>,
     ) -> Self::Output {
         wrap_channel_log(self, source, label)
@@ -306,7 +306,7 @@ impl<T: Send + std::fmt::Debug + 'static> InstrumentLog
     fn instrument_log(
         self,
         source: &'static str,
-        label: Option<&'static str>,
+        label: Option<String>,
         capacity: Option<usize>,
     ) -> Self::Output {
         if capacity.is_none() {

--- a/crates/channels-console/src/wrappers/tokio.rs
+++ b/crates/channels-console/src/wrappers/tokio.rs
@@ -11,7 +11,7 @@ use crate::{init_stats_state, ChannelType, StatsEvent, CHANNEL_ID_COUNTER};
 fn wrap_channel_impl<T, F>(
     inner: (Sender<T>, Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
     mut log_on_send: F,
 ) -> (Sender<T>, Receiver<T>)
 where
@@ -115,7 +115,7 @@ where
 pub(crate) fn wrap_channel<T: Send + 'static>(
     inner: (Sender<T>, Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
 ) -> (Sender<T>, Receiver<T>) {
     wrap_channel_impl(inner, source, label, |_| None)
 }
@@ -124,7 +124,7 @@ pub(crate) fn wrap_channel<T: Send + 'static>(
 pub(crate) fn wrap_channel_log<T: Send + std::fmt::Debug + 'static>(
     inner: (Sender<T>, Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
 ) -> (Sender<T>, Receiver<T>) {
     wrap_channel_impl(inner, source, label, |msg| Some(format!("{:?}", msg)))
 }
@@ -133,7 +133,7 @@ pub(crate) fn wrap_channel_log<T: Send + std::fmt::Debug + 'static>(
 fn wrap_unbounded_impl<T, F>(
     inner: (UnboundedSender<T>, UnboundedReceiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
     mut log_on_send: F,
 ) -> (UnboundedSender<T>, UnboundedReceiver<T>)
 where
@@ -236,7 +236,7 @@ where
 pub(crate) fn wrap_unbounded<T: Send + 'static>(
     inner: (UnboundedSender<T>, UnboundedReceiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
 ) -> (UnboundedSender<T>, UnboundedReceiver<T>) {
     wrap_unbounded_impl(inner, source, label, |_| None)
 }
@@ -245,7 +245,7 @@ pub(crate) fn wrap_unbounded<T: Send + 'static>(
 pub(crate) fn wrap_unbounded_log<T: Send + std::fmt::Debug + 'static>(
     inner: (UnboundedSender<T>, UnboundedReceiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
 ) -> (UnboundedSender<T>, UnboundedReceiver<T>) {
     wrap_unbounded_impl(inner, source, label, |msg| Some(format!("{:?}", msg)))
 }
@@ -254,7 +254,7 @@ pub(crate) fn wrap_unbounded_log<T: Send + std::fmt::Debug + 'static>(
 fn wrap_oneshot_impl<T, F>(
     inner: (oneshot::Sender<T>, oneshot::Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
     mut log_on_send: F,
 ) -> (oneshot::Sender<T>, oneshot::Receiver<T>)
 where
@@ -360,7 +360,7 @@ where
 pub(crate) fn wrap_oneshot<T: Send + 'static>(
     inner: (oneshot::Sender<T>, oneshot::Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
 ) -> (oneshot::Sender<T>, oneshot::Receiver<T>) {
     wrap_oneshot_impl(inner, source, label, |_| None)
 }
@@ -369,7 +369,7 @@ pub(crate) fn wrap_oneshot<T: Send + 'static>(
 pub(crate) fn wrap_oneshot_log<T: Send + std::fmt::Debug + 'static>(
     inner: (oneshot::Sender<T>, oneshot::Receiver<T>),
     source: &'static str,
-    label: Option<&'static str>,
+    label: Option<String>,
 ) -> (oneshot::Sender<T>, oneshot::Receiver<T>) {
     wrap_oneshot_impl(inner, source, label, |msg| Some(format!("{:?}", msg)))
 }
@@ -381,7 +381,7 @@ impl<T: Send + 'static> Instrument for (Sender<T>, Receiver<T>) {
     fn instrument(
         self,
         source: &'static str,
-        label: Option<&'static str>,
+        label: Option<String>,
         _capacity: Option<usize>,
     ) -> Self::Output {
         wrap_channel(self, source, label)
@@ -393,7 +393,7 @@ impl<T: Send + 'static> Instrument for (UnboundedSender<T>, UnboundedReceiver<T>
     fn instrument(
         self,
         source: &'static str,
-        label: Option<&'static str>,
+        label: Option<String>,
         _capacity: Option<usize>,
     ) -> Self::Output {
         wrap_unbounded(self, source, label)
@@ -405,7 +405,7 @@ impl<T: Send + 'static> Instrument for (oneshot::Sender<T>, oneshot::Receiver<T>
     fn instrument(
         self,
         source: &'static str,
-        label: Option<&'static str>,
+        label: Option<String>,
         _capacity: Option<usize>,
     ) -> Self::Output {
         wrap_oneshot(self, source, label)
@@ -419,7 +419,7 @@ impl<T: Send + std::fmt::Debug + 'static> InstrumentLog for (Sender<T>, Receiver
     fn instrument_log(
         self,
         source: &'static str,
-        label: Option<&'static str>,
+        label: Option<String>,
         _capacity: Option<usize>,
     ) -> Self::Output {
         wrap_channel_log(self, source, label)
@@ -433,7 +433,7 @@ impl<T: Send + std::fmt::Debug + 'static> InstrumentLog
     fn instrument_log(
         self,
         source: &'static str,
-        label: Option<&'static str>,
+        label: Option<String>,
         _capacity: Option<usize>,
     ) -> Self::Output {
         wrap_unbounded_log(self, source, label)
@@ -447,7 +447,7 @@ impl<T: Send + std::fmt::Debug + 'static> InstrumentLog
     fn instrument_log(
         self,
         source: &'static str,
-        label: Option<&'static str>,
+        label: Option<String>,
         _capacity: Option<usize>,
     ) -> Self::Output {
         wrap_oneshot_log(self, source, label)

--- a/crates/channels-console/tests/cli_tests_futures.rs
+++ b/crates/channels-console/tests/cli_tests_futures.rs
@@ -25,7 +25,8 @@ pub mod tests {
 
         assert!(!output.stderr.is_empty(), "Stderr is empty");
         let all_expected = [
-            "examples/basic_futures.rs",
+            "Actor 1",
+            "bounded-channel",
             "oneshot-labeled",
             "bounded[10]",
             "notified",
@@ -198,7 +199,8 @@ pub mod tests {
         }
 
         let all_expected = [
-            "basic_futures.rs",
+            "Actor 1",
+            "bounded-channel",
             "oneshot-labeled",
             "bounded[10]",
             "notified",
@@ -255,15 +257,15 @@ pub mod tests {
         let stdout = String::from_utf8_lossy(&output.stdout);
 
         let all_expected = [
-            "examples/iter_futures.rs:17",
-            "examples/iter_futures.rs:17-2",
-            "examples/iter_futures.rs:17-3",
+            "Actor 1",
+            "Actor 1-2",
+            "Actor 1-3",
             "bounded",
             "bounded-2",
             "bounded-3",
-            "examples/iter_futures.rs:50",
-            "examples/iter_futures.rs:50-2",
-            "examples/iter_futures.rs:50-3",
+            "examples/iter_futures.rs:58",
+            "examples/iter_futures.rs:58-2",
+            "examples/iter_futures.rs:58-3",
         ];
 
         for expected in all_expected {

--- a/crates/channels-console/tests/cli_tests_std.rs
+++ b/crates/channels-console/tests/cli_tests_std.rs
@@ -24,7 +24,7 @@ pub mod tests {
         );
 
         assert!(!output.stderr.is_empty(), "Stderr is empty");
-        let all_expected = ["examples/basic_std.rs", "bounded[10]"];
+        let all_expected = ["Actor 1", "unbounded-channel", "bounded[10]"];
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         for expected in all_expected {
@@ -144,7 +144,7 @@ pub mod tests {
             panic!("Failed after 4 retries: {}", error);
         }
 
-        let all_expected = ["basic_std.rs", "bounded[10]"];
+        let all_expected = ["Actor 1", "unbounded-channel", "bounded[10]"];
         for expected in all_expected {
             assert!(
                 json_text.contains(expected),
@@ -197,9 +197,9 @@ pub mod tests {
         let stdout = String::from_utf8_lossy(&output.stdout);
 
         let all_expected = [
-            "examples/iter_std.rs:17",
-            "examples/iter_std.rs:17-2",
-            "examples/iter_std.rs:17-3",
+            "Actor 1",
+            "Actor 1-2",
+            "Actor 1-3",
             "bounded",
             "bounded-2",
             "bounded-3",

--- a/crates/channels-console/tests/cli_tests_tokio.rs
+++ b/crates/channels-console/tests/cli_tests_tokio.rs
@@ -25,7 +25,8 @@ pub mod tests {
 
         assert!(!output.stderr.is_empty(), "Stderr is empty");
         let all_expected = [
-            "examples/basic_tokio.rs",
+            "Actor 1",
+            "bounded-channel",
             "hello-there",
             "unbounded",
             "bounded[10]",
@@ -198,7 +199,7 @@ pub mod tests {
             panic!("Failed after 4 retries: {}", error);
         }
 
-        let all_expected = ["basic_tokio.rs", "hello-there"];
+        let all_expected = ["Actor 1", "bounded-channel", "hello-there"];
         for expected in all_expected {
             assert!(
                 json_text.contains(expected),
@@ -251,15 +252,15 @@ pub mod tests {
         let stdout = String::from_utf8_lossy(&output.stdout);
 
         let all_expected = [
-            "bounded",
-            "bounded-2",
-            "bounded-3",
-            "examples/iter_tokio.rs:29",
-            "examples/iter_tokio.rs:29-2",
-            "examples/iter_tokio.rs:29-3",
-            "examples/iter_tokio.rs:44",
-            "examples/iter_tokio.rs:44-2",
-            "examples/iter_tokio.rs:44-3",
+            "Actor 1",
+            "Actor 1-2",
+            "Actor 1-3",
+            "examples/iter_tokio.rs:37",
+            "examples/iter_tokio.rs:37-2",
+            "examples/iter_tokio.rs:37-3",
+            "examples/iter_tokio.rs:52",
+            "examples/iter_tokio.rs:52-2",
+            "examples/iter_tokio.rs:52-3",
         ];
 
         for expected in all_expected {


### PR DESCRIPTION
The `instrument` macro only accepts a literal string for the label field. But this can be quite limiting, and isn't entirely necessary to be restricted to only literal strings.

For example, I am looking to implement support for this crate in kameo, but I can't provide the actor names in the instrument macro with:
```rust
channels_console::instrument!((tx, rx), label = A::name());
```

I *think* this is not a breaking change, so could be a minor/patch version bump.